### PR TITLE
fix(#24): phase 1 offline bootstrap page + TTY guard hardening

### DIFF
--- a/open_chat.html
+++ b/open_chat.html
@@ -1,1 +1,296 @@
-<meta http-equiv="refresh" content="0; url=http://127.0.0.1:8300">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>agentchattr</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: #0b0d10;
+    color: #e6e6e6;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    padding: 2rem 1rem;
+  }
+  h1 {
+    font-size: 2.5rem;
+    margin: 0 0 0.5rem;
+    letter-spacing: -0.02em;
+    font-weight: 600;
+  }
+  .subtitle {
+    color: #888;
+    font-size: 1rem;
+    margin-bottom: 2rem;
+    text-align: center;
+  }
+  .status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.55rem 1.1rem;
+    background: #1a1d22;
+    border: 1px solid #2a2e35;
+    border-radius: 999px;
+    font-size: 0.95rem;
+    margin-bottom: 1.5rem;
+  }
+  .dot {
+    width: 10px; height: 10px;
+    border-radius: 50%;
+    background: #666;
+    flex-shrink: 0;
+  }
+  .status.checking .dot { background: #eab308; animation: pulse 1.2s ease-in-out infinite; }
+  .status.online   .dot { background: #22c55e; }
+  .status.offline  .dot { background: #ef4444; }
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50%      { opacity: 0.35; }
+  }
+  .card {
+    max-width: 560px;
+    width: 100%;
+    background: #141619;
+    border: 1px solid #262a31;
+    border-radius: 12px;
+    padding: 1.5rem;
+    display: none;
+  }
+  .card.show { display: block; }
+  .card h2 {
+    margin: 0 0 0.4rem;
+    font-size: 1.1rem;
+    font-weight: 600;
+  }
+  .card p {
+    color: #a7a7a7;
+    margin: 0 0 1rem;
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+  .cmd {
+    display: flex;
+    gap: 0.5rem;
+    background: #0b0d10;
+    border: 1px solid #262a31;
+    border-radius: 8px;
+    padding: 0.6rem 0.9rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.9rem;
+    align-items: center;
+  }
+  .cmd code {
+    flex: 1;
+    overflow-x: auto;
+    white-space: nowrap;
+    color: #e6e6e6;
+  }
+  .cmd button {
+    background: #2a2e35;
+    border: 1px solid #3a3f48;
+    color: #e6e6e6;
+    border-radius: 6px;
+    padding: 0.35rem 0.8rem;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-family: inherit;
+    flex-shrink: 0;
+  }
+  .cmd button:hover { background: #3a3f48; }
+  .cmd button.ok { background: #15803d; border-color: #16a34a; }
+  .all-cmds { display: none; }
+  .all-cmds.show { display: block; margin-top: 1rem; }
+  .all-cmds h3 {
+    margin: 0 0 0.5rem;
+    font-size: 0.9rem;
+    color: #a7a7a7;
+    font-weight: 500;
+  }
+  .all-cmds .cmd { margin-bottom: 0.5rem; }
+  .hint {
+    color: #666;
+    font-size: 0.85rem;
+    margin-top: 1rem;
+    text-align: center;
+  }
+  .hint a {
+    color: #888;
+    text-decoration: none;
+    border-bottom: 1px dotted #555;
+    cursor: pointer;
+  }
+  .hint a:hover { color: #bbb; }
+</style>
+</head>
+<body>
+  <h1>agentchattr</h1>
+  <div class="subtitle">Local chat server for AI coding agents</div>
+
+  <div class="status checking" id="status">
+    <span class="dot"></span>
+    <span id="status-text">Checking server&hellip;</span>
+  </div>
+
+  <div class="card" id="offline-card">
+    <h2>Server is offline</h2>
+    <p>Start the server from a terminal in the repository root. This page will redirect automatically once the server is reachable.</p>
+    <div class="cmd">
+      <code id="cmd-text">./macos-linux/start.sh</code>
+      <button id="copy-btn" type="button">Copy</button>
+    </div>
+    <div class="all-cmds" id="all-cmds">
+      <h3>Other platforms</h3>
+      <div class="cmd"><code>./macos-linux/start.sh</code><button data-copy="./macos-linux/start.sh" type="button">Copy</button></div>
+      <div class="cmd"><code>windows\start.bat</code><button data-copy="windows\start.bat" type="button">Copy</button></div>
+    </div>
+    <div class="hint">
+      <a id="show-all">Not this platform?</a>
+    </div>
+  </div>
+
+<script>
+(function () {
+  "use strict";
+
+  var SERVER_URL      = "http://127.0.0.1:8300/";
+  var PROBE_TIMEOUT   = 2000;
+  var BACKOFF_INITIAL = 1000;
+  var BACKOFF_MAX     = 5000;
+
+  var statusEl    = document.getElementById("status");
+  var statusText  = document.getElementById("status-text");
+  var offlineCard = document.getElementById("offline-card");
+  var cmdText     = document.getElementById("cmd-text");
+  var copyBtn     = document.getElementById("copy-btn");
+  var showAll     = document.getElementById("show-all");
+  var allCmds     = document.getElementById("all-cmds");
+
+  function detectPlatform() {
+    var ua   = (navigator.userAgent || "").toLowerCase();
+    var plat = (navigator.platform  || "").toLowerCase();
+    if (plat.indexOf("win") === 0 || ua.indexOf("windows") !== -1) return "windows";
+    if (plat.indexOf("mac") !== -1 || ua.indexOf("mac os")  !== -1) return "unix";
+    if (plat.indexOf("linux") !== -1 || ua.indexOf("linux") !== -1) return "unix";
+    return null;
+  }
+
+  function setDefaultCommand() {
+    var p = detectPlatform();
+    if (p === "windows") {
+      cmdText.textContent = "windows\\start.bat";
+    } else if (p === "unix") {
+      cmdText.textContent = "./macos-linux/start.sh";
+    } else {
+      // Unknown platform: show everything by default so user can't pick wrong.
+      allCmds.classList.add("show");
+    }
+  }
+
+  function markCopied(btn) {
+    var orig = btn.textContent;
+    btn.textContent = "Copied";
+    btn.classList.add("ok");
+    setTimeout(function () {
+      btn.textContent = orig;
+      btn.classList.remove("ok");
+    }, 1200);
+  }
+
+  function copyText(text, btn) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(
+        function () { markCopied(btn); },
+        function () { fallbackCopy(text, btn); }
+      );
+    } else {
+      fallbackCopy(text, btn);
+    }
+  }
+
+  function fallbackCopy(text, btn) {
+    var ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.position = "fixed";
+    ta.style.opacity  = "0";
+    document.body.appendChild(ta);
+    ta.select();
+    try { document.execCommand("copy"); markCopied(btn); } catch (e) { /* noop */ }
+    document.body.removeChild(ta);
+  }
+
+  copyBtn.addEventListener("click", function () {
+    copyText(cmdText.textContent, copyBtn);
+  });
+
+  var others = document.querySelectorAll("[data-copy]");
+  for (var i = 0; i < others.length; i++) {
+    (function (b) {
+      b.addEventListener("click", function () { copyText(b.getAttribute("data-copy"), b); });
+    })(others[i]);
+  }
+
+  showAll.addEventListener("click", function (e) {
+    e.preventDefault();
+    allCmds.classList.toggle("show");
+  });
+
+  // CORS-safe reachability probe.
+  // mode: "no-cors" makes the request fire-and-forget — the opaque response
+  // is enough to confirm the server is listening. A network failure (server
+  // down) rejects; a 404/redirect/etc still resolves, which is what we want.
+  function probe() {
+    return new Promise(function (resolve) {
+      var controller = (typeof AbortController !== "undefined") ? new AbortController() : null;
+      var timer = setTimeout(function () {
+        if (controller) controller.abort();
+        resolve(false);
+      }, PROBE_TIMEOUT);
+
+      var opts = { mode: "no-cors", cache: "no-store" };
+      if (controller) opts.signal = controller.signal;
+
+      fetch(SERVER_URL, opts).then(
+        function () { clearTimeout(timer); resolve(true); },
+        function () { clearTimeout(timer); resolve(false); }
+      );
+    });
+  }
+
+  function showOffline() {
+    statusEl.className = "status offline";
+    statusText.textContent = "Server offline";
+    offlineCard.classList.add("show");
+  }
+
+  function showOnline() {
+    statusEl.className = "status online";
+    statusText.textContent = "Server online \u2014 redirecting\u2026";
+    offlineCard.classList.remove("show");
+    setTimeout(function () { window.location.href = SERVER_URL; }, 300);
+  }
+
+  var backoff = BACKOFF_INITIAL;
+
+  function tick() {
+    probe().then(function (up) {
+      if (up) { showOnline(); return; }
+      showOffline();
+      setTimeout(tick, backoff);
+      backoff = Math.min(Math.round(backoff * 1.5), BACKOFF_MAX);
+    });
+  }
+
+  setDefaultCommand();
+  tick();
+})();
+</script>
+</body>
+</html>

--- a/run.py
+++ b/run.py
@@ -156,6 +156,14 @@ def main():
             sys.exit(1)
         else:
             print()
+            # Fail fast on non-TTY so headless launchers don't block on input()
+            # waiting forever. The guard itself is not bypassed — a real terminal
+            # is still required to type YES.
+            if not sys.stdin.isatty():
+                print("  !! Non-interactive session: cannot prompt for YES confirmation.", file=sys.stderr)
+                print("  Network exposure requires explicit confirmation from a terminal.", file=sys.stderr)
+                print("  Run from an interactive terminal, or bind to 127.0.0.1 for headless use.\n", file=sys.stderr)
+                sys.exit(1)
             try:
                 confirm = input("  Type YES to accept these risks and start: ").strip()
             except (EOFError, KeyboardInterrupt):


### PR DESCRIPTION
## Summary
Implements **phase 1** of #24 per PM scope decision: a client-only offline bootstrap/recovery page and a non-TTY fail-fast in the network safety guard. No embedded `Start Server` action, no always-on helper, no native launcher — those belong to phase 2.

- **`open_chat.html`** is now a proper offline bootstrap page:
  - Dark UI with agentchattr branding and live status pill
  - Client-side reachability probe with exponential backoff (1s → 5s cap)
  - Auto-redirects to `http://127.0.0.1:8300/` as soon as the server is up
  - Platform-specific start command with 1-click copy; unknown platforms see both
  - Graceful fallback to `document.execCommand('copy')` when Clipboard API is unavailable
- **`run.py`** hardens the existing network-mode guard:
  - Adds a `sys.stdin.isatty()` check before `input()` so headless launchers fail fast with a clear stderr message instead of hanging forever
  - The interactive `YES` confirmation itself is unchanged — security posture intact

## Design choices (addressing reviewer notes from #24)
- **CORS-safe probe**: uses `fetch(..., { mode: "no-cors" })` with `AbortController` timeout. Opaque-response resolution = reachable; rejection = down. Works when the page is loaded via `file://` without needing the server to set `Access-Control-Allow-Origin`.
- **No bookmark breakage**: `open_chat.html` kept at the same path. Existing users who bookmarked the file keep the same entry point.
- **Safe OS detection**: when `navigator.platform`/UA don't yield a known match, both commands are shown by default.
- **Security-neutral**: no new endpoints, no privileged actions, no guard bypass. The TTY check only changes the failure mode (fail-fast stderr vs. silent hang), not the confirmation requirement.

## Test plan
- [x] `python3 -c 'import ast; ast.parse(open(\"run.py\").read())'` — syntax OK
- [ ] Open `open_chat.html` via `file://` while server is down → offline card with copy-button appears, status pill red
- [ ] Start the server in another terminal → status flips to green within ~1–5s, page redirects to `http://127.0.0.1:8300/`
- [ ] Open the page while server is already up → immediate redirect, no offline card flash
- [ ] Click "Not this platform?" → reveals all commands
- [ ] Launch `python run.py` with `host` set to a non-localhost value, `--allow-network` passed, stdin redirected to `/dev/null` → exits quickly with clear stderr, no hang
- [ ] Launch the same from a normal interactive terminal → prompts for `YES` as before

## Out of scope (phase 2)
- Embedded one-click `Start Server` action from the browser
- Always-on bootstrap listener / launcher daemon
- Native launcher app (Tauri/Electron/PyWebView)

🤖 Generated with [Claude Code](https://claude.com/claude-code)