### PR TITLE
feat(#39): add DeepSeek + OpenRouter API agent docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,44 @@ The wrapper registers with the server, watches for @mentions, reads recent chat 
 
 Available models: `MiniMax-M2.7` (default), `MiniMax-M2.7-highspeed` (faster), `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`. China mainland users can change `base_url` to `https://api.minimaxi.com/v1` in `config.toml`.
 
+### OpenRouter (cloud API, multi-model gateway)
+
+[OpenRouter](https://openrouter.ai) exposes hundreds of models — Qwen, DeepSeek, Mistral, Anthropic, etc. — through a single OpenAI-compatible endpoint. Add as many as you want as separate API agents in `config.local.toml`:
+
+1. Get an API key at [openrouter.ai](https://openrouter.ai)
+
+2. Set the environment variable:
+   ```bash
+   export OPENROUTER_API_KEY=your-key-here
+   ```
+
+3. Add an agent block in `config.local.toml` for each model you want. The agent name is the local handle you'll @-mention; `model` is the OpenRouter slug:
+   ```toml
+   [agents.qwen3]
+   type = "api"
+   base_url = "https://openrouter.ai/api/v1"
+   model = "qwen/qwen3.6-plus"
+   color = "#7c3aed"
+   label = "Qwen3"
+   api_key_env = "OPENROUTER_API_KEY"
+
+   [agents.deepseek]
+   type = "api"
+   base_url = "https://openrouter.ai/api/v1"
+   model = "deepseek/deepseek-v4-pro"
+   color = "#4d6bfe"
+   label = "DeepSeek"
+   api_key_env = "OPENROUTER_API_KEY"
+   ```
+
+4. Launch:
+   ```bash
+   python wrapper_api.py qwen3
+   python wrapper_api.py deepseek
+   ```
+
+Each agent gets its own status pill, @mention routing, and queue — pick any model slug from [openrouter.ai/models](https://openrouter.ai/models).
+
 ## Architecture
 
 ```

--- a/config.local.toml.example
+++ b/config.local.toml.example
@@ -52,3 +52,25 @@
 # label = "MiniMax"
 # api_key_env = "MINIMAX_API_KEY"
 # temperature = 1.0
+
+# --- Example: OpenRouter (cloud API, multi-model gateway) ---
+# OpenRouter exposes hundreds of models through a single OpenAI-compatible endpoint.
+# Get an API key at https://openrouter.ai and set OPENROUTER_API_KEY in your environment.
+# Pick any model from https://openrouter.ai/models — the agent name (e.g. `qwen3`,
+# `deepseek`) is just the local handle you'll @-mention; `model` is the OpenRouter slug.
+#
+# [agents.qwen3]
+# type = "api"
+# base_url = "https://openrouter.ai/api/v1"
+# model = "qwen/qwen3.6-plus"
+# color = "#7c3aed"
+# label = "Qwen3"
+# api_key_env = "OPENROUTER_API_KEY"
+#
+# [agents.deepseek]
+# type = "api"
+# base_url = "https://openrouter.ai/api/v1"
+# model = "deepseek/deepseek-v4-pro"
+# color = "#4d6bfe"
+# label = "DeepSeek"
+# api_key_env = "OPENROUTER_API_KEY"


### PR DESCRIPTION
## Summary
- Closes #39 (fase-1 scope only)
- Adds DeepSeek (`deepseek/deepseek-v4-pro`) as a config-only OpenAI-compatible API agent via OpenRouter — same integration style as the existing Qwen 3.6 setup
- New OpenRouter (multi-model gateway) section in `README.md` so the same pattern is documented for any model on the platform
- **Zero code changes.** Re-uses the existing `wrapper_api.py` path. No wrapper/runtime/registry/role-system touches. 143/143 tests still pass.

## Scope discipline
Per PM-besluit (issue #39 thread):
- ✅ Config + docs only — no wrapper-core verbreding
- ✅ Plain chat agent, alias on existing API-runtime
- ❌ Out of scope (intentionally): tool-use, reasoner-output stripping, custom max_tokens, channel-aware role fetch in `wrapper_api.py`

## Local-only follow-up (not in this PR)
Ingmar's `config.local.toml` (gitignored) gets a corresponding `[agents.deepseek]` block so `python wrapper_api.py deepseek` works on his system. That file is intentionally excluded from the repo.

## Test plan
- [x] `python -m pytest tests/ -q` → 143/143 passed
- [x] `config_loader.load_config` resolves the new local `[agents.deepseek]` block correctly
- [ ] Smoke run on Ingmar's system: `python wrapper_api.py deepseek` registers + responds to `@deepseek` mention
- [ ] Multi-channel: @deepseek in two channels, verify channel routing
- [ ] Heartbeat + slot-rename behaves like other API agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)